### PR TITLE
Feat[feat/vec-slice-op-4]: slicing system for caVector

### DIFF
--- a/include/core/caVector.cuh
+++ b/include/core/caVector.cuh
@@ -467,6 +467,26 @@ public:
      */
     const std::vector<double>& get_init_params() const { return init_params; }
 
+    /**
+     * @brief Create a deep copy of the vector
+     * @return New caVector with independent copy of data
+     * 
+     * This method creates a completely independent copy of the vector.
+     * The new vector has its own memory and modifications don't affect the original.
+     * 
+     * Example:
+     * @code
+     * caVector<double> original(100, init_func);
+     * caVector<double> copy = original.copy();
+     * copy[0] = 999;  // original[0] remains unchanged
+     * @endcode
+     */
+    caVector<T> copy() const {
+        Logger::debug("copy: Creating deep copy of vector with size={}", size_);
+        return *this;  // Calls the copy constructor
+    }
+
+
     // ===== UTILITY METHODS =====
 
     /**

--- a/include/core/caVector.cuh
+++ b/include/core/caVector.cuh
@@ -11,6 +11,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <algorithm>
+#include <climits>
 
 /**
  * @file caVector.cuh
@@ -256,8 +257,11 @@ public:
      * - Sets is_on_gpu_ flag to true and clears dirty flags
      */
     void ensure_on_gpu() {
+        Logger::debug("ensure_on_gpu: is_on_gpu_={} host_dirty_={} gpu_dirty_={}", is_on_gpu_, host_dirty_, gpu_dirty_);
+        
         if (!is_on_gpu_) {
             // First time: allocate GPU memory and transfer data
+            Logger::debug("ensure_on_gpu: First time - allocating GPU memory for size={}", size_);
             gpu_buffer = std::make_unique<GpuBuffer<T>>(size_);
 
             // Transfer data from HOST to GPU using our MemoryTransfer namespace
@@ -270,8 +274,10 @@ public:
             is_on_gpu_ = true;
             host_dirty_ = false;
             gpu_dirty_ = false;
+            Logger::debug("ensure_on_gpu: GPU memory allocated and data transferred");
         } else if (host_dirty_) {
             // HOST was modified: transfer HOST to GPU to sync
+            Logger::debug("ensure_on_gpu: HOST dirty - syncing HOST to GPU");
             MemoryTransfer::host_to_gpu(
                 gpu_buffer->get_pointer(),
                 host_data.data(),
@@ -283,8 +289,11 @@ public:
         } else if (gpu_dirty_) {
             // GPU was marked as dirty: HOST data is correct, just clear flags
             // No need to transfer HOST → GPU since HOST has the latest data
+            Logger::debug("ensure_on_gpu: GPU dirty - clearing flags (HOST has latest data)");
             host_dirty_ = false;
             gpu_dirty_ = false;
+        } else {
+            Logger::debug("ensure_on_gpu: No action needed - GPU is up-to-date");
         }
         // If all flags are false, no action needed (GPU is already up-to-date)
     }
@@ -403,7 +412,10 @@ public:
      * Throws std::out_of_range if index is invalid.
      */
     T& at(size_t index) {
+        Logger::debug("at: Accessing index={} in vector of size={}", index, size_);
+        
         if (index >= size_) {
+            Logger::error("at: Index {} out of range (size: {})", index, size_);
             throw std::out_of_range("caVector: index " + std::to_string(index) + " out of range (size: " + std::to_string(size_) + ")");
         }
 
@@ -412,9 +424,11 @@ public:
         
         // Only mark GPU as dirty if GPU exists
         if (is_on_gpu_) {
+            Logger::debug("at: Marking GPU as dirty for index={}", index);
             gpu_dirty_ = true; // Mark GPU as dirty
         }
 
+        Logger::debug("at: Returning value at index={}", index);
         return host_data[index];
     }
 
@@ -593,6 +607,24 @@ public:
     // ===== SLICING OPERATIONS =====
 
     /**
+     * @brief Internal structure for normalized slice parameters
+     * 
+     * This structure normalizes all slice parameters to ensure consistent
+     * and safe handling of slicing operations.
+     */
+    struct NormalizedSlice {
+        size_t start;      // Normalized start index (always >= 0 and < size)
+        size_t stop;       // Normalized stop index (always >= 0 and <= size)
+        int step;          // Step size (can be positive or negative)
+        bool is_reverse;   // True if step < 0
+        
+        NormalizedSlice(size_t s, size_t st, int stp, bool rev)
+            : start(s), stop(st), step(stp), is_reverse(rev) {}
+    };
+
+public:
+
+    /**
      * @brief Create a slice of the vector
      * @param start Starting index (inclusive)
      * @param stop Ending index (exclusive)
@@ -607,70 +639,39 @@ public:
      * - slice(0, 10, 2) → elements [0, 2, 4, 6, 8]
      * - slice(5, 0, -1) → elements [5, 4, 3, 2, 1] (reverse)
      */
-    caVector<T> slice(size_t start, size_t stop, size_t step = 1) const {
-        // Validate parameters
-        if (step == 0) {
-            throw std::invalid_argument("caVector::slice: step cannot be zero");
-        }
-
-        // Handle negative indices (Python-style)
-        if (start >= size_) start = size_;
-        if (stop > size_) stop = size_;
-
-        // Handle reverse slicing
-        if (step < 0) {
-            if (start >= size_) start = size_ - 1;
-            if (stop > size_) stop = size_;
-            if (start < stop) {
-                // Swap start and stop for reverse slicing
-                std::swap(start, stop);
-            }
-        }
-
-        // Calculate slice size
-        size_t slice_size = 0;
-        if (step > 0) {
-            if (start < stop) {
-                slice_size = (stop - start + step - 1) / step;
-            }
-        } else {
-            if (start > stop) {
-                slice_size = (start - stop - step - 1) / (-step);
-            }
-        }
-
+    caVector<T> slice(int start, int stop, int step = 1) const {
+        Logger::debug("slice: Called with start={} stop={} step={}", start, stop, step);
+        
+        // Use the new robust slicing system
+        NormalizedSlice normalized = normalize_slice(start, stop, step);
+        size_t slice_size = calculate_slice_size(normalized);
+        
+        Logger::debug("slice: Calculated slice_size={}", slice_size);
+        
         if (slice_size == 0) {
             // Return empty vector
-            return caVector<T>(0, [](T*, size_t, const std::vector<double>&) {}, {});
+            Logger::debug("slice: Returning empty vector");
+            caVector<T> result(1, [](T*, size_t, const std::vector<double>&) {}, {});
+            result.size_ = 0;
+            result.host_data.clear();
+            return result;
         }
-
-        // Create new vector with slice size
-        caVector<T> result(slice_size, [](T*, size_t, const std::vector<double>&) {}, {});
-
-        // Copy data from slice
-        size_t src_idx = start;
-        size_t dst_idx = 0;
-
-        if (step > 0) {
-            // Forward slicing
-            while (src_idx < stop && dst_idx < slice_size) {
-                result.host_data[dst_idx] = host_data[src_idx];
-                src_idx += step;
-                dst_idx++;
+        
+        // Create result vector with proper size
+        Logger::debug("slice: Creating result vector with size={}", slice_size);
+        caVector<T> result(slice_size, [](T* data, size_t size, const std::vector<double>&) {
+            // Initialize with zeros to ensure proper size
+            for (size_t i = 0; i < size; ++i) {
+                data[i] = T(0);
             }
-        } else {
-            // Reverse slicing
-            while (src_idx > stop && dst_idx < slice_size) {
-                result.host_data[dst_idx] = host_data[src_idx];
-                src_idx += step;  // step is negative
-                dst_idx++;
-            }
-        }
-
-        // Ensure the result vector has the correct size
-        result.size_ = dst_idx;
-        result.host_data.resize(dst_idx);
-
+        }, {});
+        
+        // Copy data using the helper method
+        copy_slice_data(normalized, result);
+        
+        Logger::debug("slice: Completed - result.size_={} result.host_data.size()={}", 
+                     result.size_, result.host_data.size());
+        
         return result;
     }
 
@@ -700,11 +701,14 @@ public:
         , init_function(other.init_function)
         , init_params(other.init_params) {
 
+        Logger::debug("copy constructor: Creating copy of vector with size={}", size_);
+        
         // Copy HOST data
         host_data = other.host_data;
 
         // Note: GPU data is not copied (starts fresh on HOST)
         // Dirty flags are reset for the new copy
+        Logger::debug("copy constructor: Copy completed - host_data.size()={}", host_data.size());
     }
 
     /**
@@ -714,6 +718,8 @@ public:
      */
     caVector& operator=(const caVector& other) {
         if (this != &other) {
+            Logger::debug("copy assignment: Assigning vector with size={} to existing vector", other.size_);
+            
             size_ = other.size_;
             is_on_gpu_ = false;  // Reset to HOST
             host_dirty_ = false;  // Reset dirty flags
@@ -726,6 +732,10 @@ public:
 
             // Reset GPU buffer (will be reallocated when needed)
             gpu_buffer.reset();
+            
+            Logger::debug("copy assignment: Assignment completed - host_data.size()={}", host_data.size());
+        } else {
+            Logger::debug("copy assignment: Self-assignment detected, no action taken");
         }
         return *this;
     }
@@ -774,6 +784,134 @@ public:
             other.gpu_dirty_ = false;
         }
         return *this;
+    }
+
+    // ===== SLICING HELPER METHODS IMPLEMENTATION =====
+
+    NormalizedSlice normalize_slice(int start, int stop, int step) const {
+        Logger::debug("normalize_slice: Input - start={} stop={} step={} size_={}", start, stop, step, size_);
+        
+        // Validate step
+        if (step == 0) {
+            throw std::invalid_argument("caVector::normalize_slice: step cannot be zero");
+        }
+        
+        bool is_reverse = (step < 0);
+        
+        // Normalize start index
+        size_t norm_start;
+        if (start < 0) {
+            norm_start = size_ + start;  // Python: -1 means last element
+        } else {
+            norm_start = static_cast<size_t>(start);
+        }
+        
+        // Clamp start to valid range
+        if (norm_start >= size_) {
+            norm_start = is_reverse ? size_ - 1 : size_;
+        }
+        
+        // Normalize stop index
+        size_t norm_stop;
+        if (stop < 0) {
+            if (is_reverse && stop == -1) {
+                // Special case: v[::-1] - keep as size_t max to indicate "before index 0"
+                norm_stop = SIZE_MAX;
+                Logger::debug("normalize_slice: Special case v[::-1] detected - stop=SIZE_MAX");
+            } else {
+                norm_stop = size_ + stop;  // Python: -1 means last element
+            }
+        } else {
+            norm_stop = static_cast<size_t>(stop);
+        }
+        
+        // Clamp stop to valid range, but preserve SIZE_MAX for special case
+        if (norm_stop != SIZE_MAX && norm_stop > size_) {
+            norm_stop = size_;
+        }
+        
+        Logger::debug("normalize_slice: Output - start={} stop={} step={} is_reverse={}", 
+                     norm_start, norm_stop, step, is_reverse);
+        
+        return NormalizedSlice(norm_start, norm_stop, step, is_reverse);
+    }
+
+    size_t calculate_slice_size(const NormalizedSlice& slice) const {
+        Logger::debug("calculate_slice_size: Input - start={} stop={} step={} is_reverse={}", 
+                     slice.start, slice.stop, slice.step, slice.is_reverse);
+        
+        size_t slice_size = 0;
+        
+        if (!slice.is_reverse) {
+            // Forward slicing
+            if (slice.start < slice.stop) {
+                slice_size = (slice.stop - slice.start + slice.step - 1) / slice.step;
+                Logger::debug("calculate_slice_size: Forward - size = ({} - {} + {} - 1) / {} = {}", 
+                             slice.stop, slice.start, slice.step, slice.step, slice_size);
+            }
+        } else {
+            // Reverse slicing
+            if (slice.stop == SIZE_MAX) {
+                // Special case: v[::-1] - reverse entire vector
+                slice_size = slice.start + 1;
+                Logger::debug("calculate_slice_size: Special case v[::-1] - size = {} + 1 = {}", 
+                             slice.start, slice_size);
+            } else if (slice.start >= slice.stop) {
+                // For reverse slicing, start should be >= stop to have elements
+                slice_size = (slice.start - slice.stop + (-slice.step) - 1) / (-slice.step);
+                Logger::debug("calculate_slice_size: Reverse - size = ({} - {} + {} - 1) / {} = {}", 
+                             slice.start, slice.stop, -slice.step, -slice.step, slice_size);
+            }
+        }
+        
+        Logger::debug("calculate_slice_size: Output - slice_size={}", slice_size);
+        return slice_size;
+    }
+
+    void copy_slice_data(const NormalizedSlice& slice, caVector<T>& result) const {
+        Logger::debug("copy_slice_data: Starting copy - start={} stop={} step={} is_reverse={}", 
+                     slice.start, slice.stop, slice.step, slice.is_reverse);
+        
+        size_t src_idx = slice.start;
+        size_t dst_idx = 0;
+        
+        if (!slice.is_reverse) {
+            // Forward slicing
+            Logger::debug("copy_slice_data: Forward loop - src_idx < {} && dst_idx < {}", slice.stop, result.size());
+            while (src_idx < slice.stop && dst_idx < result.size()) {
+                result.host_data[dst_idx] = host_data[src_idx];
+                Logger::debug("copy_slice_data: Copied [{}] = {} to result[{}]", src_idx, host_data[src_idx], dst_idx);
+                src_idx += slice.step;
+                dst_idx++;
+            }
+        } else {
+            // Reverse slicing
+            if (slice.stop == SIZE_MAX) {
+                // Special case: v[::-1] - reverse entire vector
+                Logger::debug("copy_slice_data: Special case v[::-1] loop - src_idx >= 0 && dst_idx < {}", result.size());
+                while (src_idx >= 0 && dst_idx < result.size()) {
+                    result.host_data[dst_idx] = host_data[src_idx];
+                    Logger::debug("copy_slice_data: Copied [{}] = {} to result[{}]", src_idx, host_data[src_idx], dst_idx);
+                    src_idx += slice.step;  // step is negative
+                    dst_idx++;
+                }
+            } else {
+                // Normal reverse slicing
+                Logger::debug("copy_slice_data: Normal reverse loop - src_idx > {} && dst_idx < {}", slice.stop, result.size());
+                while (src_idx > slice.stop && dst_idx < result.size()) {
+                    result.host_data[dst_idx] = host_data[src_idx];
+                    Logger::debug("copy_slice_data: Copied [{}] = {} to result[{}]", src_idx, host_data[src_idx], dst_idx);
+                    src_idx += slice.step;  // step is negative
+                    dst_idx++;
+                }
+            }
+        }
+        
+        Logger::debug("copy_slice_data: Copy completed - final src_idx={} dst_idx={}", src_idx, dst_idx);
+        
+        // Update result size to actual copied elements
+        result.size_ = dst_idx;
+        result.host_data.resize(dst_idx);
     }
 };
 

--- a/include/core/caVector.cuh
+++ b/include/core/caVector.cuh
@@ -557,7 +557,7 @@ public:
     }
 
     /**
-     * @brief Smart string representation like numpy
+     * @brief Smart string representation
      * @return String representation of the vector
      */
     std::string smart_string() const {
@@ -568,6 +568,102 @@ public:
             std::string last = tail_string(5);
             return first + " ... " + last + ", size=" + std::to_string(size_);
         }
+    }
+
+    // ===== SLICING OPERATIONS =====
+
+    /**
+     * @brief Create a slice of the vector
+     * @param start Starting index (inclusive)
+     * @param stop Ending index (exclusive)
+     * @param step Step size (default: 1)
+     * @return New caVector containing the sliced data
+     * 
+     * This method creates a new vector with data from the specified range.
+     * The new vector is completely independent (deep copy).
+     * 
+     * Examples:
+     * - slice(1, 5) → elements [1, 2, 3, 4]
+     * - slice(0, 10, 2) → elements [0, 2, 4, 6, 8]
+     * - slice(5, 0, -1) → elements [5, 4, 3, 2, 1] (reverse)
+     */
+    caVector<T> slice(size_t start, size_t stop, size_t step = 1) const {
+        // Validate parameters
+        if (step == 0) {
+            throw std::invalid_argument("caVector::slice: step cannot be zero");
+        }
+
+        // Handle negative indices (Python-style)
+        if (start >= size_) start = size_;
+        if (stop > size_) stop = size_;
+
+        // Handle reverse slicing
+        if (step < 0) {
+            if (start >= size_) start = size_ - 1;
+            if (stop > size_) stop = size_;
+            if (start < stop) {
+                // Swap start and stop for reverse slicing
+                std::swap(start, stop);
+            }
+        }
+
+        // Calculate slice size
+        size_t slice_size = 0;
+        if (step > 0) {
+            if (start < stop) {
+                slice_size = (stop - start + step - 1) / step;
+            }
+        } else {
+            if (start > stop) {
+                slice_size = (start - stop - step - 1) / (-step);
+            }
+        }
+
+        if (slice_size == 0) {
+            // Return empty vector
+            return caVector<T>(0, [](T*, size_t, const std::vector<double>&) {}, {});
+        }
+
+        // Create new vector with slice size
+        caVector<T> result(slice_size, [](T*, size_t, const std::vector<double>&) {}, {});
+
+        // Copy data from slice
+        size_t src_idx = start;
+        size_t dst_idx = 0;
+
+        if (step > 0) {
+            // Forward slicing
+            while (src_idx < stop && dst_idx < slice_size) {
+                result.host_data[dst_idx] = host_data[src_idx];
+                src_idx += step;
+                dst_idx++;
+            }
+        } else {
+            // Reverse slicing
+            while (src_idx > stop && dst_idx < slice_size) {
+                result.host_data[dst_idx] = host_data[src_idx];
+                src_idx += step;  // step is negative
+                dst_idx++;
+            }
+        }
+
+        // Ensure the result vector has the correct size
+        result.size_ = dst_idx;
+        result.host_data.resize(dst_idx);
+
+        return result;
+    }
+
+    /**
+     * @brief Create a slice using a range (start:stop)
+     * @param range Pair of start and stop indices
+     * @return New caVector containing the sliced data
+     * 
+     * This is a convenience method for common slicing operations.
+     * Equivalent to slice(range.first, range.second, 1)
+     */
+    caVector<T> slice(const std::pair<size_t, size_t>& range) const {
+        return slice(range.first, range.second, 1);
     }
 
     // ===== COPY CONTROL =====

--- a/src/host/bindings/data_structures_bindings.cpp
+++ b/src/host/bindings/data_structures_bindings.cpp
@@ -30,6 +30,16 @@ void bind_data_structures(py::module_& m) {
         .def("__getitem__", [](const caVector<double>& vec, size_t index) {
             return vec[index];
         }, py::arg("index"), "Get element at specified index")
+        .def("__getitem__", [](const caVector<double>& vec, py::slice slice) {
+            // Parse Python slice to get start, stop, step
+            size_t start, stop, step, slice_length;
+            if (!slice.compute(vec.size(), &start, &stop, &step, &slice_length)) {
+                throw py::error_already_set();
+            }
+
+            // Call "our" slice method xD
+            return vec.slice(start, stop, step);
+        }, py::arg("slice"), "Get slice of vector using Python slice syntax")
         .def("__setitem__", [](caVector<double>& vec, size_t index, double value) {
             vec[index] = value;
         }, py::arg("index"), py::arg("value"), "Set element at specified index")

--- a/src/host/bindings/data_structures_bindings.cpp
+++ b/src/host/bindings/data_structures_bindings.cpp
@@ -26,16 +26,28 @@ void bind_data_structures(py::module_& m) {
         .def("print_info", &caVector<double>::print_info)
         .def("get_memory_info", &caVector<double>::get_memory_info)
         .def("get_init_params", &caVector<double>::get_init_params)
+        .def("copy", &caVector<double>::copy, "Create a deep copy of the vector")
         .def("__len__", &caVector<double>::size)
         .def("__getitem__", [](const caVector<double>& vec, size_t index) {
             return vec[index];
         }, py::arg("index"), "Get element at specified index")
         .def("__getitem__", [](const caVector<double>& vec, py::slice slice) {
             // Parse Python slice to get start, stop, step
-            size_t start, stop, step, slice_length;
+            py::ssize_t start, stop, step, slice_length;
             if (!slice.compute(vec.size(), &start, &stop, &step, &slice_length)) {
                 throw py::error_already_set();
             }
+
+            Logger::debug("Python slice: start={} stop={} step={} slice_length={}", start, stop, step, slice_length);
+
+            // Special case: v[::-1] - detect when Python passes v[4:4:-1] instead of v[4:-1:-1]
+            if (step < 0 && start == vec.size() - 1 && stop == start) {
+                // This is likely v[::-1], force stop to -1
+                stop = -1;
+                Logger::debug("Detected v[::-1] pattern, forcing stop=-1");
+            }
+
+            Logger::debug("Final slice parameters: start={} stop={} step={}", start, stop, step);
 
             // Call "our" slice method xD
             return vec.slice(start, stop, step);

--- a/tests/frontend/test_copy_method.py
+++ b/tests/frontend/test_copy_method.py
@@ -1,0 +1,68 @@
+import pytest
+import cato as ca
+
+def test_copy_method():
+    """Test the copy method functionality"""
+    
+    # Create original vector
+    v = ca.vector(10, ca.constant(5.0))
+    print(f"Original vector v: {v}")
+    print(f"v[0] = {v[0]}")
+    
+    # Make a copy using the copy method
+    w = v.copy()
+    print(f"Copy w: {w}")
+    print(f"v[0] = {v[0]}, w[0] = {w[0]}")
+    
+    # Verify they are equal but not the same object
+    print(f"Are v and w equal? {v == w}")
+    print(f"Are v and w the same object? {v is w}")
+    
+    # Modify the copy
+    print(f"Modifying w[0] to 999.0...")
+    w[0] = 999.0
+    
+    print(f"After modification:")
+    print(f"v: {v}")
+    print(f"w: {w}")
+    print(f"v[0] = {v[0]}, w[0] = {w[0]}")
+    
+    # Verify independence
+    assert v[0] == 5.0, "Original vector should remain unchanged"
+    assert w[0] == 999.0, "Copy should be modified"
+    assert v != w, "Vectors should no longer be equal after modification"
+    
+    print("Copy method test passed!")
+
+def test_copy_vs_assignment():
+    """Test copy method vs assignment operator"""
+    
+    v = ca.vector(5, ca.constant(10.0))
+    
+    # Assignment (reference)
+    w1 = v
+    w1[0] = 100.0
+    
+    # Copy method (independent)
+    w2 = v.copy()
+    w2[0] = 200.0
+    
+    print(f"Original v: {v}")
+    print(f"Assignment w1: {w1}")
+    print(f"Copy w2: {w2}")
+    
+    # Verify behavior
+    assert v[0] == 100.0, "Assignment should modify original"
+    assert w1[0] == 100.0, "Assignment reference should be modified"
+    assert w2[0] == 200.0, "Copy should be independent"
+    
+    print("Copy vs assignment test passed!")
+
+if __name__ == "__main__":
+    print("=== Testing Copy Method ===")
+    test_copy_method()
+    
+    print("\n=== Testing Copy vs Assignment ===")
+    test_copy_vs_assignment()
+    
+    print("\nAll copy method tests passed!")

--- a/tests/frontend/test_slicing.py
+++ b/tests/frontend/test_slicing.py
@@ -1,0 +1,244 @@
+import pytest
+import cato as ca
+
+class TestSlicing:
+    """Test suite for caVector slicing operations"""
+    
+    def setup_method(self):
+        """Setup test vector before each test"""
+        self.vec = ca.vector(20, ca.constant(5))
+        # Set some specific values for testing
+        for i in range(5):
+            self.vec[i] = i  # [0, 1, 2, 3, 4, 5, 5, 5, ...]
+
+    def test_basic_slicing(self):
+        """Test basic slicing operations"""
+        # Basic slice
+        result = self.vec[0:5]
+        assert result.size() == 5
+        assert result[0] == 0
+        assert result[4] == 4
+
+        # Slice with step
+        result = self.vec[0:10:2]
+        assert result.size() == 5
+        assert result[0] == 0
+        assert result[1] == 2
+        assert result[2] == 4
+        assert result[3] == 5
+        assert result[4] == 5
+    
+    def test_edge_cases(self):
+        """Test edge cases and boundary conditions"""
+        # Empty slice
+        result = self.vec[5:5]
+        assert result.size() == 0
+
+        # Single element slice
+        result = self.vec[5:6]
+        assert result.size() == 1
+        assert result[0] == 5
+
+        # Slice beyond bounds
+        result = self.vec[15:25]
+        assert result.size() == 5
+        assert result[0] == 5
+
+        # Slice from beyond bounds
+        result = self.vec[25:30]
+        assert result.size() == 0
+
+    def test_negative_step(self):
+        """Test reverse slicing with negative step"""
+        # Reverse slice
+        result = self.vec[10:0:-1]
+        assert result.size() == 10
+        assert result[0] == 5  # First element of result
+        assert result[9] == 1  # Last element of result (index 1 from original)
+
+        # Reverse slice with step
+        result = self.vec[15:5:-2]
+        assert result.size() == 5
+        assert result[0] == 5
+        assert result[1] == 5
+        assert result[2] == 5
+        assert result[3] == 5
+        assert result[4] == 5
+
+    def test_default_parameters(self):
+        """Test slicing with default start/stop/step"""
+        # Default start (0)
+        result = self.vec[:5]
+        assert result.size() == 5
+        assert result[0] == 0
+
+        # Default stop (size)
+        result = self.vec[15:]
+        assert result.size() == 5
+        assert result[0] == 5
+
+        # Default step (1)
+        result = self.vec[0:5:]
+        assert result.size() == 5
+        assert result[0] == 0
+        assert result[4] == 4
+
+    def test_independence(self):
+        """Test that sliced vectors are independent"""
+        original = self.vec[0:5]
+        modified = self.vec[0:5]
+
+        # Modify the slice
+        modified[0] = 999
+
+        # Original should remain unchanged
+        assert original[0] == 0
+        assert modified[0] == 999
+
+        # Original vector should remain unchanged
+        assert self.vec[0] == 0
+
+    def test_large_step(self):
+        """Test slicing with large step values"""
+        # Large step
+        result = self.vec[0:20:5]
+        assert result.size() == 4
+        assert result[0] == 0
+        assert result[1] == 5
+        assert result[2] == 5
+        assert result[3] == 5
+
+        # Step larger than slice
+        result = self.vec[0:5:10]
+        assert result.size() == 1
+        assert result[0] == 0
+
+    def test_zero_step_error(self):
+        """Test that zero step raises error"""
+        with pytest.raises(Exception):  # Should raise std::invalid_argument
+            self.vec[0:10:0]
+
+    def test_memory_consistency(self):
+        """Test memory consistency after slicing"""
+        # Ensure original vector is still accessible
+        assert self.vec.size() == 20
+        assert self.vec[0] == 0
+        assert self.vec[19] == 5
+
+        # Multiple slices should work
+        slice1 = self.vec[0:5]
+        slice2 = self.vec[5:10]
+        slice3 = self.vec[10:15]
+
+        assert slice1.size() == 5
+        assert slice2.size() == 5
+        assert slice3.size() == 5
+
+        # All slices should be independent
+        slice1[0] = 100
+        slice2[0] = 200
+        slice3[0] = 300
+
+        assert self.vec[0] == 0  # Original unchanged
+        assert self.vec[5] == 5  # Original unchanged
+        assert self.vec[10] == 5  # Original unchanged
+
+    def test_full_reverse_slice(self):
+        """Test the special case v[::-1] - reverse entire vector"""
+        # Test with our special case detection
+        result = self.vec[::-1]
+        # Vector has 20 elements: [0,1,2,3,4,5,5,5,...,5] -> reversed
+        expected = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 4, 3, 2, 1, 0]
+        assert result.size() == 20
+        # Check first few and last few elements to avoid long list comparison
+        assert result[0] == 5   # Last element of original
+        assert result[15] == 4  # Element at index 4 of original
+        assert result[16] == 3  # Element at index 3 of original
+        assert result[17] == 2  # Element at index 2 of original
+        assert result[18] == 1  # Element at index 1 of original
+        assert result[19] == 0  # First element of original
+        
+        # Verify it's a deep copy (independent)
+        result[0] = 999
+        assert self.vec[19] == 5  # Original unchanged
+        assert result[0] == 999  # Copy modified
+
+    def test_edge_case_slicing(self):
+        """Test edge cases that could break slicing"""
+        # Empty slice from middle
+        result = self.vec[5:5]
+        assert result.size() == 0
+        
+        # Single element slice
+        result = self.vec[3:4]
+        assert result.size() == 1
+        assert result[0] == 3
+        
+        # Slice with step larger than vector
+        result = self.vec[0::15]
+        assert result.size() == 2
+        assert result[0] == 0
+        assert result[1] == 5   # 0 + 15 = 15 (within bounds, but value is 5 from constant)
+        
+        # Negative step with small range
+        result = self.vec[2:0:-1]
+        assert result.size() == 2
+        assert result[0] == 2
+        assert result[1] == 1
+
+    def test_boundary_conditions(self):
+        """Test boundary conditions that could cause issues"""
+        # Slice at exact boundaries
+        result = self.vec[0:20]
+        assert result.size() == 20
+        
+        # Slice with negative indices
+        result = self.vec[-5:-1]
+        assert result.size() == 4
+        assert result[0] == 5  # index 15
+        assert result[3] == 5  # index 18
+        
+        # Slice with mixed positive/negative
+        result = self.vec[0:-1]
+        assert result.size() == 19
+        assert result[0] == 0
+        assert result[18] == 5  # index 18
+
+if __name__ == "__main__":
+    # Run tests manually
+    test = TestSlicing()
+    test.setup_method()
+
+    print("Running slicing tests...")
+
+    test.test_basic_slicing()
+    print("Basic slicing passed")
+
+    test.test_edge_cases()
+    print("Edge cases passed")
+
+    test.test_negative_step()
+    print("Negative step passed")
+
+    test.test_default_parameters()
+    print("Default parameters passed")
+
+    test.test_independence()
+    print("Independence test passed")
+
+    test.test_large_step()
+    print("Large step passed")
+
+    test.test_memory_consistency()
+    print("Memory consistency passed")
+
+    test.test_full_reverse_slice()
+    print("Full reverse slice passed")
+
+    test.test_edge_case_slicing()
+    print("Edge case slicing passed")
+
+    test.test_boundary_conditions()
+    print("Boundary conditions passed")
+
+    print("\nAll slicing tests passed!")


### PR DESCRIPTION
Close: None
__

## **Summary**
Complete implementation of the slicing operator `[start:stop:step]` for the `caVector` class, including robust handling of edge cases and special detection for the `v[::-1]` case. This last one is a trap (?

## **Features**

- **Standard slicing**: `v[start:stop:step]` with full Python support
- **Negative step**: `v[10:0:-1]` for reverse slicing
- **Final Boss**: `v[::-1]` for complete vector reversal
- **`.copy()` method**: Creation of independent copies

**Note:**
- **Special detection**: Trap in pybind11 for `v[::-1]` when Python passes `v[size-1:size-1:-1]` (yeah, I know it could've been better, but it is what it is for now.)

## **Technical considerations**
- **`v[::-1]` is a specific "trap"**: Not a general reverse mechanism, but special detection in pybind11
- **Lazy copy**: Slices create independent copies, not shared references
